### PR TITLE
Display plugins that were installed or updated from an upgrade

### DIFF
--- a/classes/details_helper.php
+++ b/classes/details_helper.php
@@ -1,0 +1,94 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace report_upgradelog;
+
+use core_text;
+use moodle_url;
+use html_writer;
+
+/**
+ * Helper class for plugin updates and installation details.
+ *
+ * @package    report_upgradelog
+ * @copyright  2025 Alex Damsted <alexdamsted@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class details_helper {
+    /**
+     * Build link to plugin upgrade details report.
+     *
+     * @param string $value Unused
+     * @param \stdClass $row Report row
+     * @return string
+     */
+    public static function build_details(string $value, \stdClass $row): string {
+        global $DB;
+
+        if (empty($row->timemodified)) {
+            return '';
+        }
+
+        $start = (int)$row->timemodified;
+        $end   = $start + 60;
+
+        // Count plugin installs vs upgrades in the time window.
+        $sql = "
+        SELECT
+            SUM(CASE WHEN version IS NULL OR version = '' THEN 1 ELSE 0 END) AS installed,
+            SUM(CASE WHEN version IS NOT NULL AND version <> '' THEN 1 ELSE 0 END) AS updated
+        FROM {upgrade_log}
+        WHERE plugin <> :core
+          AND info IN (:installinfo, :upgradeinfo)
+          AND timemodified >= :start
+          AND timemodified < :end
+    ";
+
+        $params = [
+            'core'        => 'core',
+            'installinfo' => 'Starting plugin installation',
+            'upgradeinfo' => 'Starting plugin upgrade',
+            'start'       => $start,
+            'end'         => $end,
+        ];
+
+        $counts = $DB->get_record_sql($sql, $params);
+
+        $installed = (int)($counts->installed ?? 0);
+        $updated   = (int)($counts->updated ?? 0);
+
+        // If nothing happened, don’t show a link.
+        if ($installed === 0 && $updated === 0) {
+            return '';
+        }
+
+        $url = new \moodle_url('/report/upgradelog/details.php', [
+            'start' => $start,
+            'end'   => $end,
+        ]);
+
+        $summary = get_string(
+            'upgradepluginsummary',
+            'report_upgradelog',
+            (object)[
+                'installed' => $installed,
+                'updated'   => $updated,
+            ]
+        );
+
+        return format_text($row->info, FORMAT_PLAIN) . ': ' . html_writer::link($url, $summary);
+    }
+}

--- a/classes/local/entities/plugin_upgrade.php
+++ b/classes/local/entities/plugin_upgrade.php
@@ -1,0 +1,140 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+declare(strict_types=1);
+
+namespace report_upgradelog\local\entities;
+
+use lang_string;
+use core_reportbuilder\local\entities\base;
+use core_reportbuilder\local\report\column;
+use core_reportbuilder\local\report\filter;
+use core_reportbuilder\local\filters\date;
+
+/**
+ * Plugin upgrade/install entity.
+ *
+ * @package    report_upgradelog
+ * @copyright  2026 Alex Damsted <alexdamsted@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class plugin_upgrade extends base {
+    /**
+     * Returns default tables used by this entity.
+     *
+     * @return string[]
+     */
+    protected function get_default_tables(): array {
+        return ['upgrade_log'];
+    }
+
+    /**
+     * Default title for this entity.
+     *
+     * @return lang_string
+     */
+    protected function get_default_entity_title(): lang_string {
+        return new lang_string('pluginupgrades', 'report_upgradelog');
+    }
+
+    /**
+     * Initialise entity: add columns and filters.
+     *
+     * @return self
+     */
+    public function initialise(): self {
+        foreach ($this->get_all_columns() as $column) {
+            $this->add_column($column);
+        }
+
+        foreach ($this->get_all_filters() as $filter) {
+            $this
+                ->add_filter($filter)
+                ->add_condition($filter);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns all columns for this entity.
+     *
+     * @return column[]
+     */
+    protected function get_all_columns(): array {
+        $ul = $this->get_table_alias('upgrade_log');
+
+        return [
+            (new column(
+                'plugin',
+                new lang_string('plugin'),
+                $this->get_entity_name()
+            ))
+                ->add_fields("{$ul}.plugin"),
+
+            (new column(
+                'version',
+                new lang_string('versionold', 'report_upgradelog'),
+                $this->get_entity_name()
+            ))
+                ->add_fields("{$ul}.version"),
+
+            (new column(
+                'targetversion',
+                new lang_string('versionnew', 'report_upgradelog'),
+                $this->get_entity_name()
+            ))
+                ->add_fields("{$ul}.targetversion"),
+
+            (new column(
+                'timemodified',
+                new lang_string('time'),
+                $this->get_entity_name()
+            ))
+                ->add_fields("{$ul}.timemodified")
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->set_is_sortable(true)
+                ->add_callback(function ($timestamp) {
+                    return \core_date::strftime(get_string('strftimerecentfull', 'langconfig'), $timestamp);
+                }),
+        ];
+    }
+
+    /**
+     * Returns all filters for this entity.
+     *
+     * @return filter[]
+     */
+    protected function get_all_filters(): array {
+        $ul = $this->get_table_alias('upgrade_log');
+
+        return [
+            (new filter(
+                date::class,
+                'timemodified',
+                new lang_string('time'),
+                $this->get_entity_name(),
+                "{$ul}.timemodified"
+            ))
+                ->set_limited_operators([
+                    date::DATE_ANY,
+                    date::DATE_RANGE,
+                    date::DATE_PREVIOUS,
+                    date::DATE_CURRENT,
+                ]),
+        ];
+    }
+}

--- a/classes/local/entities/upgrade.php
+++ b/classes/local/entities/upgrade.php
@@ -24,6 +24,7 @@ use core_reportbuilder\local\helpers\format;
 use core_reportbuilder\local\report\{column, filter};
 use core_reportbuilder\local\filters\{date, number};
 use report_upgradelog\version_helper;
+use report_upgradelog\details_helper;
 
 /**
  * Upgrade log entity class implementation
@@ -65,9 +66,9 @@ class upgrade extends base {
     /**
      * Initialize the entity
      *
-     * @return base
+     * @return self
      */
-    public function initialise(): base {
+    public function initialise(): self {
         $columns = $this->get_all_columns();
         foreach ($columns as $column) {
             $this->add_column($column);
@@ -92,20 +93,6 @@ class upgrade extends base {
         global $DB;
 
         $upgradetable = $this->get_table_alias('upgrade_log');
-
-        // Information.
-        $columns[] = (new column(
-            'information',
-            new lang_string('info'),
-            $this->get_entity_name()
-        ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TEXT)
-            ->add_fields("{$upgradetable}.info")
-            ->set_is_sortable(true, [$DB->sql_order_by_text("{$upgradetable}.info")])
-            ->add_callback(static function (string $information): string {
-                return format_text($information, FORMAT_PLAIN);
-            });
 
         // Moodle version.
         $columns[] = (new column(
@@ -141,7 +128,21 @@ class upgrade extends base {
             ->set_type(column::TYPE_TIMESTAMP)
             ->add_fields("{$upgradetable}.timemodified")
             ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+            ->add_callback(function ($timestamp) {
+                return \core_date::strftime(get_string('strftimerecentfull', 'langconfig'), $timestamp);
+            });
+
+        // Details (plugin updates triggered by this core upgrade).
+        $columns[] = (new column(
+            'information',
+            new lang_string('info'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_TEXT)
+            ->add_fields("{$upgradetable}.timemodified, {$upgradetable}.info")
+            ->set_is_sortable(false)
+            ->add_callback([details_helper::class, 'build_details']);
 
         return $columns;
     }

--- a/classes/local/systemreports/plugin_upgrades.php
+++ b/classes/local/systemreports/plugin_upgrades.php
@@ -1,0 +1,102 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+declare(strict_types=1);
+
+namespace report_upgradelog\local\systemreports;
+
+use context_system;
+use core_reportbuilder\system_report;
+use core_reportbuilder\local\helpers\database;
+use report_upgradelog\local\entities\plugin_upgrade;
+
+/**
+ * Plugin upgrade/install report.
+ *
+ * @package    report_upgradelog
+ * @copyright  2026 Alex Damsted <alexdamsted@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class plugin_upgrades extends system_report {
+    /**
+     * Initialise the report.
+     *
+     * Add entity, columns, filters and base conditions.
+     */
+    protected function initialise(): void {
+        global $DB;
+
+        // Add entity first (defines tables + aliases).
+        $entity = new plugin_upgrade();
+        $ul = $entity->get_table_alias('upgrade_log');
+
+        $this->set_main_table('upgrade_log', $ul);
+        $this->add_entity($entity);
+
+        // Restrict to plugin upgrades/installs only.
+        [$infosql, $params] = $DB->get_in_or_equal(
+            ['Starting plugin upgrade', 'Starting plugin installation'],
+            SQL_PARAMS_NAMED,
+            database::generate_param_name('_')
+        );
+
+        $this->add_base_condition_sql(
+            "{$ul}.plugin <> 'core'
+             AND {$DB->sql_compare_text("{$ul}.info")} {$infosql}",
+            $params
+        );
+
+        // Add columns and filters from entity.
+        $this->add_columns();
+        $this->add_filters();
+
+        // Enable downloads.
+        $this->set_downloadable(true, get_string('pluginupgrades', 'report_upgradelog'));
+    }
+
+    /**
+     * Determine if the current user can view this report.
+     *
+     * @return bool
+     */
+    protected function can_view(): bool {
+        return has_capability('report/upgradelog:view', context_system::instance());
+    }
+
+    /**
+     * Add report columns from the entity.
+     */
+    protected function add_columns(): void {
+        $this->add_columns_from_entities([
+            'plugin_upgrade:plugin',
+            'plugin_upgrade:version',
+            'plugin_upgrade:targetversion',
+            'plugin_upgrade:timemodified',
+        ]);
+
+        // Default sorting by time modified descending.
+        $this->set_initial_sort_column('plugin_upgrade:timemodified', SORT_DESC);
+    }
+
+    /**
+     * Add report filters from the entity.
+     */
+    protected function add_filters(): void {
+        $this->add_filters_from_entities([
+            'plugin_upgrade:timemodified',
+        ]);
+    }
+}

--- a/details.php
+++ b/details.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Entry point for showing plugin upgrades and installations report.
+ *
+ * @package    report_upgradelog
+ * @copyright  2026 Alex Damsted <alexdamsted@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use core_reportbuilder\system_report_factory;
+use report_upgradelog\local\systemreports\plugin_upgrades;
+use core_reportbuilder\local\filters\date;
+
+require_once(__DIR__ . '/../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
+require_once(__DIR__ . '/lib.php');
+
+// Set up page as an external admin page for reports.
+admin_externalpage_setup('reportupgradelog', '', null, '', [
+    'pagelayout' => 'report',
+]);
+
+// Print header and page title.
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('pluginupgrades', 'report_upgradelog'));
+
+// Generate tabs.
+if ($tabs = generate_tabs('viewall')) {
+    echo $OUTPUT->render($tabs);
+}
+
+// Instantiate the report using the system_report_factory.
+$report = system_report_factory::create(
+    plugin_upgrades::class,
+    context_system::instance()
+);
+
+// Apply a "Range" filter if start/end timestamps are provided.
+$starttime = optional_param('start', null, PARAM_INT);
+$endtime   = optional_param('end', null, PARAM_INT);
+
+if (!empty($starttime) || !empty($endtime)) {
+    $filtervalues = [
+        'plugin_upgrade:timemodified_operator' => date::DATE_RANGE,
+        'plugin_upgrade:timemodified_from'     => $starttime,
+        'plugin_upgrade:timemodified_to'       => $endtime,
+    ];
+    $report->set_filter_values($filtervalues);
+} else {
+    // Unset any set filters.
+    $report->set_filter_values([]);
+}
+
+// Output the report table.
+echo $report->output();
+
+// Print page footer.
+echo $OUTPUT->footer();

--- a/lang/en/report_upgradelog.php
+++ b/lang/en/report_upgradelog.php
@@ -25,10 +25,14 @@
 defined('MOODLE_INTERNAL') || die;
 
 $string['pluginname'] = 'Upgrade log';
+$string['pluginupgrades'] = 'Plugin upgrades';
 $string['privacy:metadata'] = 'The Upgrade log plugin does not store any personal data';
 $string['unknown'] = 'Unknown';
 $string['upgrade'] = 'Upgrade';
 $string['upgradelog:view'] = 'View upgrade log';
+$string['upgradepluginsummary'] = '{$a->installed} installed, {$a->updated} updated';
 $string['upgrades'] = 'Upgrades';
 $string['upgrades_help'] = 'This report lists all core Moodle upgrades that have been performed on this site';
 $string['upgrades_link'] = 'https://moodledev.io/general/releases';
+$string['versionnew'] = 'New version';
+$string['versionold'] = 'Old version';

--- a/lib.php
+++ b/lib.php
@@ -15,32 +15,33 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Entry point for showing upgrades report
+ * Lib file.
  *
  * @package    report_upgradelog
- * @copyright  2019 Paul Holden <paulh@moodle.com>
+ * @copyright  2026 Alex Damsted <alexdamsted@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use core_reportbuilder\system_report_factory;
-use report_upgradelog\local\systemreports\upgrades;
+/**
+ * Returns navigation controls (tabtree).
+ *
+ * @param string $currenttab The current tab
+ * @return tabtree
+ */
+function generate_tabs(string $currenttab): tabtree {
+    $tabs = [];
 
-require_once(__DIR__ . '/../../config.php');
-require_once($CFG->libdir . '/adminlib.php');
-require_once(__DIR__ . '/lib.php');
+    $tabs[] = new tabobject(
+        'view',
+        new moodle_url('/report/upgradelog/index.php'),
+        get_string('pluginname', 'report_upgradelog')
+    );
 
-admin_externalpage_setup('reportupgradelog', '', null, '', ['pagelayout' => 'report']);
+    $tabs[] = new tabobject(
+        'viewall',
+        new moodle_url('/report/upgradelog/details.php'),
+        get_string('pluginupgrades', 'report_upgradelog')
+    );
 
-echo /** @var core_renderer $OUTPUT */ $OUTPUT->header();
-
-echo $OUTPUT->heading_with_help(get_string('pluginname', 'report_upgradelog'), 'upgrades', 'report_upgradelog');
-
-// Generate tabs.
-if ($tabs = generate_tabs('view')) {
-    echo $OUTPUT->render($tabs);
+    return new tabtree($tabs, $currenttab);
 }
-
-$report = system_report_factory::create(upgrades::class, context_system::instance());
-echo $report->output();
-
-echo $OUTPUT->footer();


### PR DESCRIPTION
Hello, 

This PR addresses the following issue: https://github.com/paulholden/moodle-report_upgradelog/issues/1

----

**What this PR is looking to do**

- Display what plugins were installed and/or updated during a core Moodle upgrade and display this information in a readable manner. E.g., by creating a new tab tree and using the Moodle report builder to display the plugins on a separate page.

----

**Considerations**

MDL-87313 introduces uninstalled plugins to the upgrade log database table: https://github.com/moodle/moodle/compare/main...christianabila:moodle:MDL-87313

This means we can show plugin uninstalls alongside plugins installations and upgrades/downgrades.

I am looking at adding in this feature to my fork in the near future.

----

Thanks!